### PR TITLE
Add the remainder of the To Do Items

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: WhatAreWeFixingToday
+custom: ["https://www.paypal.com/paypalme/SirGoodenough", "https://www.buymeacoffee.com/SirGoodenough"]

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Another good thing to do before you ask for help is try testing what you have in
 
 # Test if a list is a valid RGB color list
 
-## 'chkRGB(_rgbl)'
+## `chkRGB(_rgbl)`
 
 This will test a list to make sure it’s a valid RGB color list.
 
@@ -360,7 +360,7 @@ for help sorting this out.
 
 # Test if a list is a valid XY color list
 
-## 'chkXY(_xyl)'
+## `chkXY(_xyl)`
 
 This will test a list to make sure it’s a valid XY color list.
 
@@ -387,7 +387,7 @@ for help sorting this out.
 
 # Test if a list is a valid HS color list
 
-## 'chkHS(_hsl)'
+## `chkHS(_hsl)`
 
 This will test a list to make sure it’s a valid HS color list.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ This requires HomeAssistant version 2023.11.0 or greater due to the use of the l
 # 🦠 TO-DO List
 
 - ~~Push to HACS Custom.~~
-- Error checking inputs for range.
-- Add ```Display closest color name to a given RGB```.
-- Clean-up code, add shortcuts on redundancies.
-- Return a list of all the official color names.
+- ~~Error checking inputs for range.~~
+- ~~Return a list of all the official color names.~~
+- ~~Clean-up code, add shortcuts on redundancies.~~
 - Push to Hacs released.
+- Add ```Display closest color name to a given RGB```.
 
 # 🔩 Installation
 
@@ -410,6 +410,46 @@ for help sorting this out.
   REMEMBER:
     This always returns text, so cast to bool on the other end to be
     certain of the result.
+
+*********************
+
+## `chkNAME(color_name)`
+
+Is this color name on the official list?
+This will test a provided color name to see if it is on the HA color list.
+
+First we need to make sure it’s a string_like variable.
+Then we test that the string is only lowercase letters to match the HA list.
+Then we iterate thru the list to make sure it is on the list.
+If all that is true return true.
+If any is not true, return false.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import chkNAME %}
+    {{ chkNAME('orange') | bool }}
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+
+*********************
+
+## `color_list()`
+
+  This will return all of the official color names recognized by Home Assistant
+    lifted directly from the Home Assistant core github November, 2023 at
+    https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py
+    and the Official CSS3 colors from w3.org:
+    https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
+    Names do not have spaces in them so that we can compare against
+    requests more easily (by removing spaces from the requests as well).
+    This lets "dark seagreen" and "dark sea green" both match the same
+    color "darkseagreen". 
+    You also get the RGB color code for each of the color names.
+  
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import color_list() %}
+    {{- color_list() -}}
 
 ### Other Info
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,89 @@ Another good thing to do before you ask for help is try testing what you have in
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
+    list as shown in the example above.
+
+*********************
+
+# Test if a list is a valid RGB color list
+
+## 'chkRGB(_rgbl)'
+
+This will test a list to make sure it’s a valid RGB color list.
+
+First we need to make sure it’s a list, and that the list has 3 members.
+Then we need to test that each member is a number, an integer, and between 0 & 255.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @Didgeridrew and @jeffcrum on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/3)
+for help sorting this out.
+
+  SAMPLE USAGE:
+
+```jinja
+    {% from 'color_multi_tool.jinja' import chkRGB %}
+    {{ chkRGB([255,165,0]) | bool }}
+```
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+
+*********************
+
+# Test if a list is a valid XY color list
+
+## 'chkXY(_xyl)'
+
+This will test a list to make sure it’s a valid XY color list.
+
+First we need to make sure it’s a list, and that the list has 2 members.
+Then we need to test that each member is a number, and between 0 & 1.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @123 on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
+for help sorting this out.
+
+  SAMPLE USAGE:
+
+```jinja
+    {% from 'color_multi_tool.jinja' import chkXY %}
+    {{ chkXY([0.497,0.472]) | bool }}
+```
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+
+*********************
+
+# Test if a list is a valid HS color list
+
+## 'chkHS(_hsl)'
+
+This will test a list to make sure it’s a valid HS color list.
+
+First we need to make sure it’s a list, and that the list has 2 members.
+Then we need to test that each member is a number.
+The first one has to be 0 to 100, the second one has to be 0 to 360.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @123 on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
+for help sorting this out.
+
+  SAMPLE USAGE:
+
+```jinja
+    {% from 'color_multi_tool.jinja' import chkHS %}
+    {{ chkHS([38.824,100.0]) | bool }}
+```
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
 
 ### Other Info
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Custom Template for doing things with colors.
 
 Custom Template for doing things with colors. It started out by wanting a way to get a random color name off of the official color name list. Then I decided it needed a way to pull random rgb, hs, and xy colors as well. I then decided to build the conversions between all the types.
 
-The conversions are derived from HA's own color conversion code with the exception of rgb2hs.  Home Assistant uses the built-in python module to do that in core, so I pulled the code for that from another source.
+The conversions are derived from HA's own color conversion code with the exception of rgb2hs. Home Assistant uses the built-in python module to do that in core, so I pulled the code for that from another source.
 
 I followed the conversion code as close as I could, but I find that if you convert a color then convert it back, it drifts quite a bit.
 
-I welcome the PR from anyone that can improve any of this code.  It is 'functional' but not optimized at this point, and there are things I want to do with it.  However I wanted to release it for others to collab at this point.
+I welcome the PR from anyone that can improve any of this code. It is 'functional' but not optimized at this point. In several cases I don't understand the code, I just ported it over, hopefully successfully. PR's are welcome.
 
 Documentation for this Custom Template can be found at:
 
@@ -46,9 +46,9 @@ You *may* need to enable 'experimental features' mode. To do this find the HACS 
 #### Other help
 
 Before you report a 'Bug', you need to make sure you have read the accompanying Descriptions on the templates and this README and have followed all the settings required here.
-This is important because if these instructions are not followed, you will likely have a bad day and be forced to contact me for help.  Not that I don't want to help, but personal interaction takes me a while to respond and is generally non-productive.
+This is important because if these instructions are not followed, you will likely have a bad day and be forced to contact me for help. Not that I don't want to help, but personal interaction takes me a while to respond and is generally non-productive.
 
-Another good thing to do before you ask for help is try testing what you have in the Developer Tools Template Tab in Home Assistant. There you can adjust this and that until you figure out the answer to your question yourself.  
+Another good thing to do before you ask for help is try testing what you have in the Developer Tools Template Tab in Home Assistant. There you can adjust this and that until you figure out the answer to your question yourself. At the end of the color table in the code is the developer code that I use to test everything. If you provide any PR's make sure you load this and test all the things.
 
 [![Open your Home Assistant instance and show your template developer tools.](https://my.home-assistant.io/badges/developer_template.svg)](https://my.home-assistant.io/redirect/developer_template/)
 
@@ -58,12 +58,12 @@ Another good thing to do before you ask for help is try testing what you have in
 
 ## `random_name()`
 
-  This will return one of the official color names recognized by Home Assistant lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py and the Official CSS3 colors from w3.org: https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4    
-  
+  This will return one of the official color names recognized by Home Assistant lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py and the Official CSS3 colors from w3.org: https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
+
   Names do not have spaces in them so that we can compare against requests more easily (by removing spaces from the requests as well).
-  
+
   This lets "dark seagreen" and "dark sea green" both match the same color "darkseagreen".
-  
+
 ### SAMPLE USAGE:
 
   ```jinja
@@ -78,7 +78,7 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `random_xy()`
 
   This will return a CSV string that will convert to a list for a random color in the x,y format.
-  
+
   SAMPLE USAGE:
 
   ```jinja
@@ -120,7 +120,7 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `random_rgb()`
 
   This will return a CSV string that will convert to a list for a random color in the rgb format.
-  
+
   SAMPLE USAGE:
 
   ```jinja
@@ -140,20 +140,20 @@ Another good thing to do before you ask for help is try testing what you have in
 
 ## `name2rgb(color_name)`
 
-  This will return the RGB value for an official color name recognized by Home Assistant lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py and the Official CSS3 colors from w3.org: https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4    
-  
+  This will return the RGB value for an official color name recognized by Home Assistant lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py and the Official CSS3 colors from w3.org: https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
+
   Names do not have spaces in them so that we can compare against requests more easily (by removing spaces from the requests as well).
-  
+
   This lets "dark seagreen" and "dark sea green" both match the same color "darkseagreen".
-  
+
   Names do not have spaces in them so that we can compare against requests more easily (by removing spaces from the requests as well) 
-  
+
   This lets "dark seagreen" and "dark sea green" both match the same color "darkseagreen".
-  
+
   You have to type in her correct name. The text you send me will be set to no spaces and lower case to match the data as described above.
-  
+
   If the name is not found, it will return "0.0.0", IE black, because then name you provided is not a color.
-  
+
   SAMPLE USAGE:
 
   ```jinja
@@ -168,18 +168,38 @@ Another good thing to do before you ask for help is try testing what you have in
 
 *********************
 
+# Return the Color Name for a Provided rgb Number
+
+## `rgb2name(_range, rgbl)`
+
+  This template will accept a list representing an RGB value plus a range value representing the window size of the 'close enough' color name. It will return the Home Assistant Color name that matches it or is close to it within a +/- range you specify.
+
+- If you want only an exact match, then set the range to 0.
+- If you think that +10/-10 is close enough, then set the range to 10.
+
+  For default the color is set to black [0,0,0] and the range is 0, so it will by give you ['black'] for invalid input.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import rgb2name %}
+    {{ name2rgb(color_name) }}
+
+  REMEMBER:
+    Everything returned from a macro template is a string.
+
+*********************
+
 # Return the xy Number for a Provided rgb Number
 
 ## `rgb2xy(rgb_formatted_list)`
 
   This will return a CSV string that will convert to a list in the x,y format from the rgb list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   Code lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py.
-  
+
   Brightness is assumed to be 100%
-  
+
   SAMPLE USAGE:
 
   ```jinja
@@ -200,13 +220,13 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `xy2rgb(xy_formatted_list)`
 
   This will return a CSV string that will convert to a list in the rgb format from the xy list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   Code lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py.
-  
+
   Brightness is assumed to be 100%
-  
+
   SAMPLE USAGE:
 
   ```jinja
@@ -227,11 +247,11 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `hs2rgb(hs_formatted_list)`
 
   This will return a CSV string that will convert to a list in the rgb format from the xy list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   Code lifted directly from the Home Assistant core github November, 2023 at https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py.
-  
+
   Brightness is assumed to be 100%
 
   SAMPLE USAGE:
@@ -254,15 +274,15 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `rgb2hs(rgb_formatted_list)`
 
   This will return a CSV string that will convert to a list in the x,y format from the rgb list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   Code lifted directly from the here November, 2023 at https://www.cs.rit.edu/~ncs/color/t_convert.html#RGB%20to%20HSV%20&%20HSV%20to%20RGB.
 
   Brightness is assumed to be 100%
-  
+
   SAMPLE USAGE:
-  
+
   ```jinja
     {% from 'color_multi_tool.jinja' import rgb2hs %}
     {% set _rgb2hs = rgb2hs(rgbl).split(",") | list -%}
@@ -281,11 +301,11 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `hs2xy(hs_formatted_list)`
 
   This will return a CSV string that will convert to a list in the hs format from the xy list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   This converter uses other templates provided in this Custom Jinja Template.
-  
+
   Brightness is assumed to be 100%
 
   SAMPLE USAGE:
@@ -308,9 +328,9 @@ Another good thing to do before you ask for help is try testing what you have in
 ## `xy2hs(xy_formatted_list)`
 
   This will return a CSV string that will convert to a list in the hs format from the xy list provided.
-  
+
   Be sure to convert this to a list when you use it on the other end because it arrives as a CSV string.
-  
+
   This converter uses other templates provided in this Custom Jinja Template.
 
   Brightness is assumed to be 100%
@@ -446,10 +466,10 @@ If any is not true, return false.
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen". 
     You also get the RGB color code for each of the color names.
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import color_list() %}
-    {{- color_list() -}}
+    {{- color_list().split('\n') | list -}}
 
 ### Other Info
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Custom Template for doing things with colors. 
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/custom-components/hacs)
 ![Version](https://img.shields.io/github/v/release/SirGoodenough/Color-Multi-Tool)
 
 <a href="https://www.buymeacoffee.com/SirGoodenough"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=SirGoodenough&button_colour=5F7FFF&font_colour=ffffff&font_family=Poppins&outline_colour=000000&coffee_colour=FFDD00" width=auto, height=30/></a>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This requires HomeAssistant version 2023.11.0 or greater due to the use of the l
 - ~~Error checking inputs for range.~~
 - ~~Return a list of all the official color names.~~
 - ~~Clean-up code, add shortcuts on redundancies.~~
+- ~~Add ```Display closest color name to a given RGB```~~
 - Push to Hacs released.
-- Add ```Display closest color name to a given RGB```.
 
 # 🔩 Installation
 

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -31,9 +31,7 @@
     {{ [_rxy[0]|float|round(3),_rxy[1]|float|round(3)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 
 {%- set X = (0.001*(range(1000)|random)) | round(3) | float(0) %}
@@ -54,9 +52,7 @@
     {{ [_rhs[0]|float|round(2),_rhs[1]|float|round(2)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {%- set H = 0.01*(range(36000)|random) | round(3) | float(0) %}
 {%- set S = 0.01*(range(10000)|random) | round(3) | float(0) %}
@@ -76,9 +72,7 @@
     {{ [_rrgb[0]|int(0),_rrgb[1]|int(0),_rrgb[2]|int(0)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {%- set R = (range(255)|random) | int(0) %}
 {%- set G = (range(255)|random) | int(0) %}
@@ -93,29 +87,24 @@
     https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py
     and the Official CSS3 colors from w3.org:
     https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
-    Names do not have spaces in them so that we can compare against
-    requests more easily (by removing spaces from the requests as well).
+    Names must not have spaces, uppercase, or punctuation in them so that we can
+    compare against requests more easily .
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen".
-  You have to type in her correct name. The text you send me will be set to no
-    spaces and lower case to match the data as described above.
-  If the name is not found, it will return "0.0.0", IE black,
-    because then name you provided is not a color.
+  If the exact name is not found, it will return "0.0.0", IE black,
+    because then name you provided is not a color on the official list.
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import name2rgb %}
     {{ name2rgb(color_name) }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
-{%- if color_name is string_like %}
-  {%- set _color = color_name | regex_replace('[^a-z]', '') %}
-  {%- set R = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='r') | first | default([]) %}
-  {%- set G = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='g') | first | default([]) %}
-  {%- set B = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='b') | first | default([]) %}
+{%- if chkNAME(color_name) | bool %}
+  {%- set R = _nameMap['_rgb'] | selectattr('color', 'eq', color_name) | map(attribute='r') | first | default([]) %}
+  {%- set G = _nameMap['_rgb'] | selectattr('color', 'eq', color_name) | map(attribute='g') | first | default([]) %}
+  {%- set B = _nameMap['_rgb'] | selectattr('color', 'eq', color_name) | map(attribute='b') | first | default([]) %}
 {%- else %}
   {%- set R = 0 %}
   {%- set G = 0 %}
@@ -140,9 +129,7 @@
     {{ [_rgb2xy[0]|float|round(3),_rgb2xy[1]|float|round(3)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {%- if chkRGB(rgbl) | bool %}
   {%- set iR = rgbl[0] | int(0) %}
@@ -209,9 +196,7 @@
     {{ [_xy2rgb[0]|int(0),_xy2rgb[1]|int(0),_xy2rgb[2]|int(0)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {#- First a test to make sure this is a list #}
 {%- if chkXY(xyl) | bool %}
@@ -282,9 +267,7 @@
     {{ [_hs2rgb[0]|int(0),_hs2rgb[1]|int(0),_hs2rgb[2]|int(0)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {#- First a test to make sure this is a list #}
 {%- if chkHS(hsl) | bool %}
@@ -360,9 +343,7 @@
     {{[ _rgb2hs[0]|float(0)|round(3),_rgb2hs[1]|float(0)|round(3)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {#- First tests to make sure this is a list #}
 {%- if chkRGB(rgbl) | bool %}
@@ -427,9 +408,7 @@
     {{ [_hs2xy[0]|float|round(3),_hs2xy[1]|float|round(3)] }} 
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {#- First a test to make sure this is a list #}
 {%- if chkHS(hsl) | bool %}
@@ -463,9 +442,7 @@
     {{ [_xy2hs[0]|float|round(3),_xy2hs[1]|float|round(3)] }}
 
   REMEMBER:
-    Everything returned from a macro template is a string, so for
-    conventional usage of colors the result needs to be converted to a
-    list as shown in the example above.
+    Everything returned from a macro template is a string.
 #}
 {#- First a test to make sure this is a list #}
 {%- if chkXY(xyl) | bool %}
@@ -490,8 +467,8 @@ This will test a list to make sure it’s a valid RGB color list.
 
 First we need to make sure it’s a list, and that the list has 3 members.
 Then we need to test that each member is a number, an integer, and between 0 & 255.
-If all that is true return True.
-If any is not true, return False.
+If all that is true return true.
+If any is not true, return false.
 Development credit to @Didgeridrew and @jeffcrum on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/3)
 for help sorting this out.
@@ -508,7 +485,7 @@ for help sorting this out.
 {%- for clr in _rgbl if is_number(clr) and int(clr,0) == clr and 0 <= clr <= 255 %}
 {% if loop.last %}
 {{ loop.index == 3 }}
-{%- endif %}{% endfor%}{% else %}False{%- endif %}
+{%- endif %}{% endfor%}{% else %}{{ false }}{%- endif %}
 {% endmacro %}
 
 {% macro chkXY(_xyl) %}
@@ -517,8 +494,8 @@ This will test a list to make sure it’s a valid XY color list.
 
 First we need to make sure it’s a list, and that the list has 2 members.
 Then we need to test that each member is a number, and between 0 & 1.
-If all that is true return True.
-If any is not true, return False.
+If all that is true return true.
+If any is not true, return false.
 Development credit to @123 on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
 for help sorting this out.
@@ -544,8 +521,8 @@ This will test a list to make sure it’s a valid HS color list.
 First we need to make sure it’s a list, and that the list has 2 members.
 Then we need to test that each member is a number.
 The first one has to be 0 to 100, the second one has to be 0 to 360.
-If all that is true return True.
-If any is not true, return False.
+If all that is true return true.
+If any is not true, return false.
 Development credit to @123 on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
 for help sorting this out.
@@ -563,6 +540,55 @@ for help sorting this out.
    _hsl | select('<', 0) | list | count == 0 and
    _hsl[0] <= 100 and
    _hsl[1] <= 360 }}
+{% endmacro %}
+
+{% macro chkNAME(color_name) %}
+{#- Is this color name on the official list?
+This will test a provided color name to see if it is on the HA color list.
+
+First we need to make sure it’s a string_like variable.
+Then we test that the string is only lowercase letters to match the HA list.
+Then we iterate thru the list to make sure it is on the list.
+If all that is true return true.
+If any is not true, return false.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import chkNAME %}
+    {{ chkNAME('orange') | bool }}
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+#}
+{%- if color_name is string_like and 
+  color_name == color_name | regex_replace('[^a-z]', '') %}
+{%- set ns = namespace(found = false) %}
+{%- for color_item in _nameMap._rgb %}
+{%- if color_item.color == color_name %}
+{%- set ns.found = true %}
+{%- break %}{% endif %}{% endfor %}{{ ns.found }}{% else %}{{ false }}{% endif %}
+{% endmacro %}
+
+{% macro color_list() %}
+{#-
+  This will return all of the official color names recognized by Home Assistant
+    lifted directly from the Home Assistant core github November, 2023 at
+    https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py
+    and the Official CSS3 colors from w3.org:
+    https://www.w3.org/TR/2010/PR-css3-color-20101028/#html4
+    Names do not have spaces in them so that we can compare against
+    requests more easily (by removing spaces from the requests as well).
+    This lets "dark seagreen" and "dark sea green" both match the same
+    color "darkseagreen". 
+    You also get the RGB color code for each of the color names.
+  
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import randomcolor_list_name %}
+    {{- color_list() -}}
+#}
+{%- for dict_item in _nameMap._rgb %}
+{{ dict_item.color -}},{{- dict_item.r -}},{{- dict_item.g -}},{{- dict_item.b -}}
+{%- endfor %}
 {% endmacro %}
 
 {#- COLOR NAME TO RGB MAP DATA. DO NOT CHANGE BELOW THIS LINE
@@ -1160,18 +1186,19 @@ for help sorting this out.
     { 'color': 'yellowgreen',
     'r': 154,
     'g': 205,
-    'g': 50, },
+    'b': 50, },
     { 'color': 'homeassistant',
     'r': 24,
-    'b': 188,
-    'g': 242, },
+    'g': 188,
+    'b': 242, },
   ],
 } %}
 
 {#-
 TESTING CODE FOR DEVELOPER TAB TO TEST THIS CUSTOM JINJA:
-{% from 'color_multi_tool.jinja' import random_name, random_xy, random_hs, random_rgb,
-  name2rgb, rgb2xy, xy2rgb, hs2rgb, rgb2hs, xy2hs, hs2xy %}
+{% from 'color_multi_tool.jinja' import random_name, random_xy, random_hs,
+random_rgb, name2rgb, rgb2xy, xy2rgb, hs2rgb, rgb2hs, xy2hs, hs2xy, chkRGB,
+chkXY, chkHS, chkNAME, color_list %}
 0 macro random name: {{ random_name() }}
 1 macro random xy list: {% set _rxy1 = random_xy().split(",") | list %}
 {%- set _rxy1_list = [_rxy1[0]|float|round(3),_rxy1[1]|float|round(3)] %}
@@ -1206,12 +1233,16 @@ A (using #8) macro hs to xy list: {% set _hs2xyA = hs2xy(_rgb2hs8_list).split(",
 {%- set _xy2hs9_list = [_xy2hs9[0]|float(0)|round(3),_xy2hs9[1]|float(0)|round(3)] %}
 {{- _hs2xyA_list }} -> {{ _xy2hs9_list }}
 
-Test the tests by changing the list values:
+Test the tests by changing the values:
 {%- set _rgbl = [255,165,0] %}
-Check RGB: {{ chkRGB(_rgbl) | bool }}
+Check RGB:   {{ chkRGB(_rgbl) | bool }}
 {%- set _xyl = [0.497,0.472] %}
-check XY : {{ chkXY(_xyl) | bool }}
+check XY :   {{ chkXY(_xyl) | bool }}
 {%- set _hsl = [38.824,100.0] %}
-Check HS : {{ chkHS(_hsl) | bool }}
+Check HS :   {{ chkHS(_hsl) | bool }}
+{%- set _name = 'orange' %}
+Check NAME : {{ chkNAME(_name) | bool }}
 
-#}
+Test color_list:
+{{- color_list() }}
+

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -9,7 +9,7 @@
     requests more easily (by removing spaces from the requests as well).
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen". 
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_name %}
     {{- random_name() -}}
@@ -24,7 +24,7 @@
     random color in the x,y format.
   Be sure to convert this to a list when you use it on the other end
   because it arrives as a CSV string.
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_xy %}
     {% set _rxy = random_xy().split(",") | list %}
@@ -34,9 +34,8 @@
     Everything returned from a macro template is a string.
 #}
 
-{%- set X = (0.001*(range(1000)|random)) | round(3) | float(0) %}
-{%- set Y = (0.001*(range(1000)|random)) | round(3) | float(0) %}
-{{- X -}},{{- Y -}}
+{%- set (X,Y) = [range(1001),range(1001)] | map('random') | list %}
+{{- X/1000 -}},{{- Y/1000 -}}
 {% endmacro %}
 
 {% macro random_hs() %}
@@ -54,9 +53,8 @@
   REMEMBER:
     Everything returned from a macro template is a string.
 #}
-{%- set H = 0.01*(range(36000)|random) | round(3) | float(0) %}
-{%- set S = 0.01*(range(10000)|random) | round(3) | float(0) %}
-{{- H -}},{{- S -}}
+{%- set (H,S) = [range(36001),range(10001)] | map('random') | list %}
+{{- H/100 -}},{{- S/100 -}}
 {% endmacro %}
 
 {% macro random_rgb() %}
@@ -65,7 +63,7 @@
     random color in the rgb format.
   Be sure to convert this to a list when you use it on the other end
   because it arrives as a CSV string.
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_rgb %}
     {% set _rrgb = random_rgb().split(",") | list %}
@@ -74,9 +72,7 @@
   REMEMBER:
     Everything returned from a macro template is a string.
 #}
-{%- set R = (range(255)|random) | int(0) %}
-{%- set G = (range(255)|random) | int(0) %}
-{%- set B = (range(255)|random) | int(0) %}
+{% set (R,G,B) = [range(256),range(256),range(256)] | map('random') | list %}
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
@@ -93,7 +89,7 @@
     color "darkseagreen".
   If the exact name is not found, it will return "0.0.0", IE black,
     because then name you provided is not a color on the official list.
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import name2rgb %}
     {{ name2rgb(color_name) }}
@@ -169,7 +165,7 @@
   Code lifted directly from the Home Assistant core github November, 2023 at
     https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py.
   Brightness is assumed to be 100%
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2xy %}
     {% set _rgb2xy = rgb2xy(_nrgb).split(",") | list %}
@@ -236,7 +232,7 @@
   Code lifted directly from the Home Assistant core github November, 2023 at
     https://github.com/home-assistant/core/blob/dev/homeassistant/util/color.py.
   Brightness is assumed to be 100%
-  
+
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import xy2rgb %}
     {% set _xy2rgb = xy2rgb(xyl).split(",") | list %}

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -13,8 +13,8 @@
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_name %}
     {{- random_name() -}}
--#}
-{%- set _color_dict = _nameMap._rgb | random -%}
+#}
+{%- set _color_dict = _nameMap._rgb | random %}
 {{- _color_dict.color -}}
 {% endmacro %}
 
@@ -27,17 +27,17 @@
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_xy %}
-    {% set _rxy = random_xy().split(",") | list -%}
+    {% set _rxy = random_xy().split(",") | list %}
     {{ [_rxy[0]|float|round(3),_rxy[1]|float|round(3)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
+#}
 
-{%- set X = (0.001*(range(1000)|random)) | round(3) | float(0) -%}
-{%- set Y = (0.001*(range(1000)|random)) | round(3) | float(0) -%}
+{%- set X = (0.001*(range(1000)|random)) | round(3) | float(0) %}
+{%- set Y = (0.001*(range(1000)|random)) | round(3) | float(0) %}
 {{- X -}},{{- Y -}}
 {% endmacro %}
 
@@ -50,16 +50,16 @@
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_hs %}
-    {% set _rhs = random_hs().split(",") | list -%}
+    {% set _rhs = random_hs().split(",") | list %}
     {{ [_rhs[0]|float|round(2),_rhs[1]|float|round(2)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{%- set H = 0.01*(range(36000)|random) | round(3) | float(0) -%}
-{%- set S = 0.01*(range(10000)|random) | round(3) | float(0) -%}
+#}
+{%- set H = 0.01*(range(36000)|random) | round(3) | float(0) %}
+{%- set S = 0.01*(range(10000)|random) | round(3) | float(0) %}
 {{- H -}},{{- S -}}
 {% endmacro %}
 
@@ -72,17 +72,17 @@
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_rgb %}
-    {% set _rrgb = random_rgb().split(",") | list -%}
+    {% set _rrgb = random_rgb().split(",") | list %}
     {{ [_rrgb[0]|int(0),_rrgb[1]|int(0),_rrgb[2]|int(0)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{%- set R = (range(255)|random) | int(0) -%}
-{%- set G = (range(255)|random) | int(0) -%}
-{%- set B = (range(255)|random) | int(0) -%}
+#}
+{%- set R = (range(255)|random) | int(0) %}
+{%- set G = (range(255)|random) | int(0) %}
+{%- set B = (range(255)|random) | int(0) %}
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
@@ -110,17 +110,17 @@
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{%- if color_name is string_like -%}
-  {%- set _color = color_name | regex_replace('[^a-z]', '') -%}
-  {%- set R = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='r') | first | default([]) -%}
-  {%- set G = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='g') | first | default([]) -%}
-  {%- set B = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='b') | first | default([]) -%}
-{%- else -%}
-  {%- set R = 0 -%}
-  {%- set G = 0 -%}
-  {%- set B = 0 -%}
-{%- endif -%}
+#}
+{%- if color_name is string_like %}
+  {%- set _color = color_name | regex_replace('[^a-z]', '') %}
+  {%- set R = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='r') | first | default([]) %}
+  {%- set G = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='g') | first | default([]) %}
+  {%- set B = _nameMap['_rgb'] | selectattr('color', 'eq', _color) | map(attribute='b') | first | default([]) %}
+{%- else %}
+  {%- set R = 0 %}
+  {%- set G = 0 %}
+  {%- set B = 0 %}
+{%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
@@ -136,61 +136,60 @@
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2xy %}
-    {% set _rgb2xy = rgb2xy(_nrgb).split(",") | list -%}
+    {% set _rgb2xy = rgb2xy(_nrgb).split(",") | list %}
     {{ [_rgb2xy[0]|float|round(3),_rgb2xy[1]|float|round(3)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First tests to make sure this is a list -#}
-{%- if rgbl is list -%}
-  {%- set iR = rgbl[0] | int(0) -%}
-  {%- set iG = rgbl[1] | int(0) -%}
-  {%- set iB = rgbl[2] | int(0) -%}
-  {%- if iR + iG + iB != 0 -%}
-    {%- set R = iR / 255 -%}
-    {%- set B = iB / 255 -%}
-    {%- set G = iG / 255 -%}
-      {#- Gamma correction -#}
-    {%- if (R > 0.04045) -%}
-      {%- set R = ((R + 0.055) / (1.0 + 0.055) ** 2.4) -%}
-    {%- else -%}
-      {%- set R = (R / 12.92) -%}
-    {%- endif -%}
+#}
+{%- if chkRGB(rgbl) | bool %}
+  {%- set iR = rgbl[0] | int(0) %}
+  {%- set iG = rgbl[1] | int(0) %}
+  {%- set iB = rgbl[2] | int(0) %}
+  {%- if iR + iG + iB != 0 %}
+    {%- set R = iR / 255 %}
+    {%- set B = iB / 255 %}
+    {%- set G = iG / 255 %}
+      {#- Gamma correction #}
+    {%- if (R > 0.04045) %}
+      {%- set R = ((R + 0.055) / (1.0 + 0.055) ** 2.4) %}
+    {%- else %}
+      {%- set R = (R / 12.92) %}
+    {%- endif %}
 
-    {%- if (G > 0.04045) -%}
-      {%- set G = ((G + 0.055) / (1.0 + 0.055) ** 2.4) -%}
-    {%- else -%}
-      {%- set G = (G / 12.92) -%}
-    {%- endif -%}
+    {%- if (G > 0.04045) %}
+      {%- set G = ((G + 0.055) / (1.0 + 0.055) ** 2.4) %}
+    {%- else %}
+      {%- set G = (G / 12.92) %}
+    {%- endif %}
 
-    {%- if (B > 0.04045) -%}
-      {%- set B = ((B + 0.055) / (1.0 + 0.055) ** 2.4) -%}
-    {%- else -%}
-      {%- set B = (B / 12.92) -%}
-    {%- endif -%}
-      {#- Wide RGB D65 conversion formula -#}
-    {%- set X = R * 0.664511 + G * 0.154324 + B * 0.162028 -%}
-    {%- set Y = R * 0.283881 + G * 0.668433 + B * 0.047685 -%}
-    {%- set Z = R * 0.000088 + G * 0.072310 + B * 0.986039 -%}
+    {%- if (B > 0.04045) %}
+      {%- set B = ((B + 0.055) / (1.0 + 0.055) ** 2.4) %}
+    {%- else %}
+      {%- set B = (B / 12.92) %}
+    {%- endif %}
+      {#- Wide RGB D65 conversion formula #}
+    {%- set X = R * 0.664511 + G * 0.154324 + B * 0.162028 %}
+    {%- set Y = R * 0.283881 + G * 0.668433 + B * 0.047685 %}
+    {%- set Z = R * 0.000088 + G * 0.072310 + B * 0.986039 %}
       {#- Convert XYZ to xy #}
-    {%- set x = X / (X + Y + Z) -%}
-    {%- set y = Y / (X + Y + Z) -%}
-      {#- Change the output names to match this macro -#}
-    {%- set X = x | float(0) | round(3) -%}
-    {%- set Y = y | float(0) | round(3) -%}
-  {%- else -%}
-    {#- Color started as black -#}
-    {%- set X = 0.0 -%}
-    {%- set Y = 0.0 -%}
-  {%- endif -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set X = 0.0 -%}
-  {%- set Y = 0.0 -%}
-{%- endif -%}
+    {%- set x = X / (X + Y + Z) %}
+    {%- set y = Y / (X + Y + Z) %}
+      {#- Change the output names to match this macro #}
+    {%- set X = x | float(0) | round(3) %}
+    {%- set Y = y | float(0) | round(3) %}
+  {%- else %}
+    {#- Color started as black #}
+    {%- set X = 0.0 %}
+    {%- set Y = 0.0 %}
+  {%- endif %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set X = 0.0 %}
+  {%- set Y = 0.0 %}
+{%- endif %}
 {{- X -}},{{- Y -}}
 {% endmacro %}
 
@@ -206,64 +205,64 @@
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import xy2rgb %}
-    {% set _xy2rgb = xy2rgb(xyl).split(",") | list -%}
+    {% set _xy2rgb = xy2rgb(xyl).split(",") | list %}
     {{ [_xy2rgb[0]|int(0),_xy2rgb[1]|int(0),_xy2rgb[2]|int(0)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First a test to make sure this is a list -#}
-{%- if xyl is list -%}
-  {%- set vX = xyl[0] | float(0) -%}
-  {%- set vY = xyl[1] | float(0.00000000001) -%}
-  {%- set vY = vY + 0.00000000001 -%}
-  {%- set Y = 1 -%}
-  {%- set X = (Y / vY) * vX -%}
-  {%- set Z = (Y / vY) * (1 - vX - vY) -%}
-    {#- Convert to RGB using Wide RGB D65 conversion. -#}
-  {%- set r = X * 1.656492 - Y * 0.354851 - Z * 0.255038 -%}
-  {%- set g = -X * 0.707196 + Y * 1.655397 + Z * 0.036152 -%}
-  {%- set b = X * 0.051713 - Y * 0.121364 + Z * 1.011530 -%}
-    {#- Apply reverse gamma correction. -#}
-  {%- if r <= 0.0031308 -%}
-    {%- set r = 12.92 * r -%}
-  {%- else -%}
-    {%- set r = ((1.0 + 0.055) * (r ** (1.0 / 2.4)) - 0.055) -%}
-  {%- endif -%}
+#}
+{#- First a test to make sure this is a list #}
+{%- if chkXY(xyl) | bool %}
+  {%- set vX = xyl[0] | float(0) %}
+  {%- set vY = xyl[1] | float(0.00000000001) %}
+  {%- set vY = vY + 0.00000000001 %}
+  {%- set Y = 1 %}
+  {%- set X = (Y / vY) * vX %}
+  {%- set Z = (Y / vY) * (1 - vX - vY) %}
+    {#- Convert to RGB using Wide RGB D65 conversion. #}
+  {%- set r = X * 1.656492 - Y * 0.354851 - Z * 0.255038 %}
+  {%- set g = -X * 0.707196 + Y * 1.655397 + Z * 0.036152 %}
+  {%- set b = X * 0.051713 - Y * 0.121364 + Z * 1.011530 %}
+    {#- Apply reverse gamma correction. #}
+  {%- if r <= 0.0031308 %}
+    {%- set r = 12.92 * r %}
+  {%- else %}
+    {%- set r = ((1.0 + 0.055) * (r ** (1.0 / 2.4)) - 0.055) %}
+  {%- endif %}
 
-  {%- if g <= 0.0031308 -%}
-    {%- set g = 12.92 * g -%}
-  {%- else -%}
-    {%- set g = ((1.0 + 0.055) * (g ** (1.0 / 2.4)) - 0.055) -%}
-  {%- endif -%}
+  {%- if g <= 0.0031308 %}
+    {%- set g = 12.92 * g %}
+  {%- else %}
+    {%- set g = ((1.0 + 0.055) * (g ** (1.0 / 2.4)) - 0.055) %}
+  {%- endif %}
 
-  {%- if b <= 0.0031308 -%}
-    {%- set b = 12.92 * b -%}
-  {%- else -%}
-    {%- set b = ((1.0 + 0.055) * (b ** (1.0 / 2.4)) - 0.055) -%}
-  {%- endif -%}
-    {#- Bring all negative components to zero. -#}
-  {%- set r = [0, r] | max -%}
-  {%- set g = [0, g] | max -%}
-  {%- set b = [0, b] | max -%}
-    {#- If one component is greater than 1, weight components by that value. -#}
-  {%- set max_component = [r, g, b] | max -%}
-  {%- if max_component > 1 -%}
-    {%- set r = r / max_component -%}
-    {%- set g = g / max_component -%}
-    {%- set b = b / max_component -%}
-  {%- endif -%}
-  {%- set R = (r * 255) | int(0) -%}
-  {%- set G = (g * 255) | int(0) -%}
-  {%- set B = (b * 255) | int(0) -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set R = 0 -%}
-  {%- set G = 0 -%}
-  {%- set B = 0 -%}
-{%- endif -%}
+  {%- if b <= 0.0031308 %}
+    {%- set b = 12.92 * b %}
+  {%- else %}
+    {%- set b = ((1.0 + 0.055) * (b ** (1.0 / 2.4)) - 0.055) %}
+  {%- endif %}
+    {#- Bring all negative components to zero. #}
+  {%- set r = [0, r] | max %}
+  {%- set g = [0, g] | max %}
+  {%- set b = [0, b] | max %}
+    {#- If one component is greater than 1, weight components by that value. #}
+  {%- set max_component = [r, g, b] | max %}
+  {%- if max_component > 1 %}
+    {%- set r = r / max_component %}
+    {%- set g = g / max_component %}
+    {%- set b = b / max_component %}
+  {%- endif %}
+  {%- set R = (r * 255) | int(0) %}
+  {%- set G = (g * 255) | int(0) %}
+  {%- set B = (b * 255) | int(0) %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set R = 0 %}
+  {%- set G = 0 %}
+  {%- set B = 0 %}
+{%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
@@ -279,69 +278,69 @@
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import hs2rgb %}
-    {% set _hs2rgb = hs2rgb(hsl).split(",") | list -%}
+    {% set _hs2rgb = hs2rgb(hsl).split(",") | list %}
     {{ [_hs2rgb[0]|int(0),_hs2rgb[1]|int(0),_hs2rgb[2]|int(0)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First a test to make sure this is a list -#}
-{%- if hsl is list -%}
-  {%- set fH = (hsl[0] | float(0)) -%}
-  {%- set fS = (hsl[1] | float(0)) / 100 -%}
-  {%- set fB = 1 -%}
-  {%- if fS != 0.0 -%}
-    {%- set r = 0 -%}
-    {%- set g = 0 -%}
-    {%- set b = 0 -%}
-    {%- set h = fH / 60 -%}
-    {%- set f = h - (h | round(1, 'floor')) -%}
-    {%- set p = fB * (1 - fS) -%}
-    {%- set q = fB * (1 - fS * f) -%}
-    {%- set t = fB * (1 - (fS * (1 - f))) -%}
-    {%- if h | int == 0 -%}
-      {%- set r = (fB * 255) | int(0) -%}
-      {%- set g = (t * 255) | int(0) -%}
-      {%- set b = (p * 255) | int(0) -%}
-    {%- elif h | int == 1 -%}
-      {%- set r = (q * 255) | int(0) -%}
-      {%- set g = (fB * 255) | int(0) -%}
-      {%- set b = (p * 255) | int(0) -%}
-    {%- elif h | int == 2 -%}
-      {%- set r = (p * 255) | int(0) -%}
-      {%- set g = (fB * 255) | int(0) -%}
-      {%- set b = (t * 255) | int(0) -%}
-    {%- elif h | int == 3 -%}
-      {%- set r = (p * 255) | int(0) -%}
-      {%- set g = (q * 255) | int(0) -%}
-      {%- set b = (fB* 255) | int(0) -%}
-    {%- elif h | int == 4 -%}
-      {%- set r = (t * 255) | int(0) -%}
-      {%- set g = (p * 255) | int(0) -%}
-      {%- set b = (fB * 255) | int(0) -%}
-    {%- elif h | int == 5 -%}
-      {%- set r = (fB * 255) | int(0) -%}
-      {%- set g = (p * 255) | int(0) -%}
-      {%- set b = (q * 255) | int(0) -%}
-    {%- endif -%}
-    {%- set R = r | int(0) -%}
-    {%- set G = g | int(0) -%}
-    {%- set B = b | int(0) -%}
-  {%- else -%}
-    {#- Color started as white -#}
-    {%- set fV = (fB * 255) | int(0) -%}
-    {%- set R = fV | int(0) -%}
-    {%- set G = fV | int(0) -%}
-    {%- set B = fV | int(0) -%}
-  {%- endif -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set R = 0 -%}
-  {%- set G = 0 -%}
-  {%- set B = 0 -%}
-{%- endif -%}
+#}
+{#- First a test to make sure this is a list #}
+{%- if chkHS(hsl) | bool %}
+  {%- set fH = (hsl[0] | float(0)) %}
+  {%- set fS = (hsl[1] | float(0)) / 100 %}
+  {%- set fB = 1 %}
+  {%- if fS != 0.0 %}
+    {%- set r = 0 %}
+    {%- set g = 0 %}
+    {%- set b = 0 %}
+    {%- set h = fH / 60 %}
+    {%- set f = h - (h | round(1, 'floor')) %}
+    {%- set p = fB * (1 - fS) %}
+    {%- set q = fB * (1 - fS * f) %}
+    {%- set t = fB * (1 - (fS * (1 - f))) %}
+    {%- if h | int == 0 %}
+      {%- set r = (fB * 255) | int(0) %}
+      {%- set g = (t * 255) | int(0) %}
+      {%- set b = (p * 255) | int(0) %}
+    {%- elif h | int == 1 %}
+      {%- set r = (q * 255) | int(0) %}
+      {%- set g = (fB * 255) | int(0) %}
+      {%- set b = (p * 255) | int(0) %}
+    {%- elif h | int == 2 %}
+      {%- set r = (p * 255) | int(0) %}
+      {%- set g = (fB * 255) | int(0) %}
+      {%- set b = (t * 255) | int(0) %}
+    {%- elif h | int == 3 %}
+      {%- set r = (p * 255) | int(0) %}
+      {%- set g = (q * 255) | int(0) %}
+      {%- set b = (fB* 255) | int(0) %}
+    {%- elif h | int == 4 %}
+      {%- set r = (t * 255) | int(0) %}
+      {%- set g = (p * 255) | int(0) %}
+      {%- set b = (fB * 255) | int(0) %}
+    {%- elif h | int == 5 %}
+      {%- set r = (fB * 255) | int(0) %}
+      {%- set g = (p * 255) | int(0) %}
+      {%- set b = (q * 255) | int(0) %}
+    {%- endif %}
+    {%- set R = r | int(0) %}
+    {%- set G = g | int(0) %}
+    {%- set B = b | int(0) %}
+  {%- else %}
+    {#- Color started as white #}
+    {%- set fV = (fB * 255) | int(0) %}
+    {%- set R = fV | int(0) %}
+    {%- set G = fV | int(0) %}
+    {%- set B = fV | int(0) %}
+  {%- endif %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set R = 0 %}
+  {%- set G = 0 %}
+  {%- set B = 0 %}
+{%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
@@ -357,59 +356,59 @@
   
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2hs %}
-    {% set _rgb2hs = rgb2hs(rgbl).split(",") | list -%}
+    {% set _rgb2hs = rgb2hs(rgbl).split(",") | list %}
     {{[ _rgb2hs[0]|float(0)|round(3),_rgb2hs[1]|float(0)|round(3)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First tests to make sure this is a list -#}
-{%- if rgbl is list -%}
-  {%- set r = rgbl[0] | int(0) -%}
-  {%- set g = rgbl[1] | int(0) -%}
-  {%- set b = rgbl[2] | int(0) -%}
-  {%- if r + g + b != 0 -%}
-    {%- set min = [r, g, b] | min -%}
-    {%- set max = [r, g, b] | max -%}
-  {#- Set brightness to 100% -#}
-    {#- set _V = max (alternate) -#}
-    {%- set _V = 255 -%}
-  {#- Calculate S -#}
-    {%- set delta = max-min -%}
-    {%- set _S = (delta / max) * 100 -%}
-  {#- Calculate H -#}
-    {%- if r == max -%}
-      {#- between yellow & magenta -#}
-      {%- set _H = ( g - b ) / delta -%}
-    {%- elif g == max -%}
-      {#- between cyan & yellow -#}
-      {%- set _H = 2 + ( b - r ) / delta -%}
-    {%- else -%}
-      {#- between magenta & cyan -#}
-      {%- set _H = 4 + ( r - g ) / delta -%}
-    {%- endif -%}
-    {%- set _H = _H * 60 -%}
-    {%- if _H < 0 -%}
-      {%- set _H = _H + 360 -%}
-    {%- endif -%}
-  {#- Calculated output -#}
-    {%- set H = _H | float(0) | round(3) -%}
-    {%- set S = _S | float(0) | round(3) -%}
-    {%- set V = _V | float(0) | round(3) -%}
-  {%- else -%}
-    {#- Color started as black -#}
-    {%- set H = 0.0 -%}
-    {%- set S = 0.0 -%}
-    {%- set V = 0.0 -%}
-  {%- endif -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set H = 0.0 -%}
-  {%- set S = 0.0 -%}
-  {%- set V = 0.0 -%}
-{%- endif -%}
+#}
+{#- First tests to make sure this is a list #}
+{%- if chkRGB(rgbl) | bool %}
+  {%- set r = rgbl[0] | int(0) %}
+  {%- set g = rgbl[1] | int(0) %}
+  {%- set b = rgbl[2] | int(0) %}
+  {%- if r + g + b != 0 %}
+    {%- set min = [r, g, b] | min %}
+    {%- set max = [r, g, b] | max %}
+  {#- Set brightness to 100% #}
+    {#- set _V = max (alternate) #}
+    {%- set _V = 255 %}
+  {#- Calculate S #}
+    {%- set delta = max-min %}
+    {%- set _S = (delta / max) * 100 %}
+  {#- Calculate H #}
+    {%- if r == max %}
+      {#- between yellow & magenta #}
+      {%- set _H = ( g - b ) / delta %}
+    {%- elif g == max %}
+      {#- between cyan & yellow #}
+      {%- set _H = 2 + ( b - r ) / delta %}
+    {%- else %}
+      {#- between magenta & cyan #}
+      {%- set _H = 4 + ( r - g ) / delta %}
+    {%- endif %}
+    {%- set _H = _H * 60 %}
+    {%- if _H < 0 %}
+      {%- set _H = _H + 360 %}
+    {%- endif %}
+  {#- Calculated output #}
+    {%- set H = _H | float(0) | round(3) %}
+    {%- set S = _S | float(0) | round(3) %}
+    {%- set V = _V | float(0) | round(3) %}
+  {%- else %}
+    {#- Color started as black #}
+    {%- set H = 0.0 %}
+    {%- set S = 0.0 %}
+    {%- set V = 0.0 %}
+  {%- endif %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set H = 0.0 %}
+  {%- set S = 0.0 %}
+  {%- set V = 0.0 %}
+{%- endif %}
 {{- H -}},{{- S -}}
 {% endmacro %}
 
@@ -424,28 +423,28 @@
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import hs2xy %}
-    {% set _hs2xy = hs2xy(hsl).split(",") | list -%}
+    {% set _hs2xy = hs2xy(hsl).split(",") | list %}
     {{ [_hs2xy[0]|float|round(3),_hs2xy[1]|float|round(3)] }} 
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First a test to make sure this is a list -#}
-{%- if hsl is list -%}
-  {%- set _hs2rgb = hs2rgb(hsl).split(",") | list -%}
-  {%- set _hs2rgb_list = [_hs2rgb[0]|int(0),_hs2rgb[1]|int(0),_hs2rgb[2]|int(0)] | list -%}
-  {%- set _rgb2xy = rgb2xy(_hs2rgb_list).split(",") | list -%}
-  {%- set _rgb2xy_list = [_rgb2xy[0]|float(0)|round(3),_rgb2xy[1]|float(0)|round(3)] | list -%}
-{#- Calculated output -#}
-  {%- set X = _rgb2xy_list[0] | float(0.0) | round(3) -%}
-  {%- set Y = _rgb2xy_list[1] | float(0.0) | round(3) -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set X = 0.0 -%}
-  {%- set Y = 0.0 -%}
-{%- endif -%}
+#}
+{#- First a test to make sure this is a list #}
+{%- if chkHS(hsl) | bool %}
+  {%- set _hs2rgb = hs2rgb(hsl).split(",") | list %}
+  {%- set _hs2rgb_list = [_hs2rgb[0]|int(0),_hs2rgb[1]|int(0),_hs2rgb[2]|int(0)] | list %}
+  {%- set _rgb2xy = rgb2xy(_hs2rgb_list).split(",") | list %}
+  {%- set _rgb2xy_list = [_rgb2xy[0]|float(0)|round(3),_rgb2xy[1]|float(0)|round(3)] | list %}
+{#- Calculated output #}
+  {%- set X = _rgb2xy_list[0] | float(0.0) | round(3) %}
+  {%- set Y = _rgb2xy_list[1] | float(0.0) | round(3) %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set X = 0.0 %}
+  {%- set Y = 0.0 %}
+{%- endif %}
 {{- X -}},{{- Y -}}
 {% endmacro %}
 
@@ -460,32 +459,114 @@
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import xy2hs %}
-    {% set _xy2hs = xy2hs(xyl).split(",") | list -%}
+    {% set _xy2hs = xy2hs(xyl).split(",") | list %}
     {{ [_xy2hs[0]|float|round(3),_xy2hs[1]|float|round(3)] }}
 
   REMEMBER:
     Everything returned from a macro template is a string, so for
     conventional usage of colors the result needs to be converted to a
     list as shown in the example above.
--#}
-{#- First a test to make sure this is a list -#}
-{%- if xyl is list -%}
-  {%- set _xy2rgb = xy2rgb(xyl).split(",") | list -%}
-  {%- set _xy2rgb_list = [_xy2rgb[0]|int(0),_xy2rgb[1]|int(0),_xy2rgb[2]|int(0)] | list -%}
-  {%- set _rgb2hs = rgb2hs(_xy2rgb_list).split(",") | list -%}
-  {%- set _rgb2hs_list = [_rgb2hs[0]|float(0)|round(3),_rgb2hs[1]|float(0)|round(3)] | list -%}
-{#- Calculated output -#}
-  {%- set H = _rgb2hs_list[0] | float(0.0) | round(3) -%}
-  {%- set S = _rgb2hs_list[1] | float(0.0) | round(3) -%}
-{%- else -%}
-  {#- Input was not a list -#}
-  {%- set H = 0.0 -%}
-  {%- set S = 0.0 -%}
-{%- endif -%}
+#}
+{#- First a test to make sure this is a list #}
+{%- if chkXY(xyl) | bool %}
+  {%- set _xy2rgb = xy2rgb(xyl).split(",") | list %}
+  {%- set _xy2rgb_list = [_xy2rgb[0]|int(0),_xy2rgb[1]|int(0),_xy2rgb[2]|int(0)] | list %}
+  {%- set _rgb2hs = rgb2hs(_xy2rgb_list).split(",") | list %}
+  {%- set _rgb2hs_list = [_rgb2hs[0]|float(0)|round(3),_rgb2hs[1]|float(0)|round(3)] | list %}
+{#- Calculated output #}
+  {%- set H = _rgb2hs_list[0] | float(0.0) | round(3) %}
+  {%- set S = _rgb2hs_list[1] | float(0.0) | round(3) %}
+{%- else %}
+  {#- Input was not a list #}
+  {%- set H = 0.0 %}
+  {%- set S = 0.0 %}
+{%- endif %}
 {{- H -}},{{- S -}}
 {% endmacro %}
 
-{#- COLOR NAME TO RGB MAP DATA. DO NOT CHANGE BELOW THIS LINE: -#}
+{% macro chkRGB(_rgbl) %}
+{#- Is the RGB list Valid? 
+This will test a list to make sure it’s a valid RGB color list.
+
+First we need to make sure it’s a list, and that the list has 3 members.
+Then we need to test that each member is a number, an integer, and between 0 & 255.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @Didgeridrew and @jeffcrum on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/3)
+for help sorting this out.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import chkRGB %}
+    {{ chkRGB([255,165,0]) | bool }}
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+#}
+{%- if _rgbl is list and _rgbl | count == 3 %}
+{%- for clr in _rgbl if is_number(clr) and int(clr,0) == clr and 0 <= clr <= 255 %}
+{% if loop.last %}
+{{ loop.index == 3 }}
+{%- endif %}{% endfor%}{% else %}False{%- endif %}
+{% endmacro %}
+
+{% macro chkXY(_xyl) %}
+{#- Is the XY list Valid? 
+This will test a list to make sure it’s a valid XY color list.
+
+First we need to make sure it’s a list, and that the list has 2 members.
+Then we need to test that each member is a number, and between 0 & 1.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @123 on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
+for help sorting this out.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import chkXY %}
+    {{ chkXY([0.497,0.472]) | bool }}
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+#}
+{{- _xyl is list and
+   _xyl | select('number') | list | count == 2 and
+   _xyl | select('<', 0) | list | count == 0 and
+   _xyl | select('>', 1) | list | count == 0 }}
+{% endmacro %}
+
+{% macro chkHS(_hsl) %}
+{#- Is the XY list Valid? 
+This will test a list to make sure it’s a valid HS color list.
+
+First we need to make sure it’s a list, and that the list has 2 members.
+Then we need to test that each member is a number.
+The first one has to be 0 to 100, the second one has to be 0 to 360.
+If all that is true return True.
+If any is not true, return False.
+Development credit to @123 on the
+[Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
+for help sorting this out.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import chkHS %}
+    {{ chkHS([38.824,100.0]) | bool }}
+
+  REMEMBER:
+    This always returns text, so cast to bool on the other end to be
+    certain of the result.
+#}
+{{- _hsl is list and
+   _hsl | select('number') | list | count == 2 and
+   _hsl | select('<', 0) | list | count == 0 and
+   _hsl[0] <= 100 and
+   _hsl[1] <= 360 }}
+{% endmacro %}
+
+{#- COLOR NAME TO RGB MAP DATA. DO NOT CHANGE BELOW THIS LINE
+    (unless you want to add your own custom color that is...): #}
 {% set _nameMap = {
   '_rgb': [
     { 'color': 'aliceblue',
@@ -1085,44 +1166,51 @@
     'b': 188,
     'g': 242, },
   ],
-} -%}
+} %}
 
 {#-
 TESTING CODE FOR DEVELOPER TAB TO TEST THIS CUSTOM JINJA:
-
 {% from 'color_multi_tool.jinja' import random_name, random_xy, random_hs, random_rgb,
   name2rgb, rgb2xy, xy2rgb, hs2rgb, rgb2hs, xy2hs, hs2xy %}
 0 macro random name: {{ random_name() }}
-1 macro random xy list: {% set _rxy1 = random_xy().split(",") | list -%}
-{% set _rxy1_list = [_rxy1[0]|float|round(3),_rxy1[1]|float|round(3)] -%}
-{{ _rxy1_list }}
-2 macro random hs list: {% set _rhs2 = random_hs().split(",") | list -%}
-{% set _rhs2_list =  [_rhs2[0]|float|round(3),_rhs2[1]|float|round(2)] -%}
-{{ _rhs2_list }} 
-3 macro random rgb list: {% set _rrgb3 = random_rgb().split(",") | list -%}
-{% set _rrgb3_list = [_rrgb3[0]|int(0),_rrgb3[1]|int(0),_rrgb3[2]|int(0)] -%}
-{{ _rrgb3_list }} 
+1 macro random xy list: {% set _rxy1 = random_xy().split(",") | list %}
+{%- set _rxy1_list = [_rxy1[0]|float|round(3),_rxy1[1]|float|round(3)] %}
+{{- _rxy1_list }}
+2 macro random hs list: {% set _rhs2 = random_hs().split(",") | list %}
+{%- set _rhs2_list =  [_rhs2[0]|float|round(3),_rhs2[1]|float|round(2)] %}
+{{- _rhs2_list }} 
+3 macro random rgb list: {% set _rrgb3 = random_rgb().split(",") | list %}
+{%- set _rrgb3_list = [_rrgb3[0]|int(0),_rrgb3[1]|int(0),_rrgb3[2]|int(0)] %}
+{{- _rrgb3_list }} 
 
 4 macro name to rgb list: {% set _nrgb4_name = random_name() %}
-{%- set _nrgb4 = name2rgb(_nrgb4_name).split(",") | list -%}
-{% set _nrgb4_list = [_nrgb4[0]|int(0),_nrgb4[1]|int(0),_nrgb4[2]|int(0)] -%}
-{{- _nrgb4_name }} {{ _nrgb4_list }}
-5 (using #4) macro rgb to xy list: {% set _rgb2zy5 = rgb2xy(_nrgb4_list).split(",") | list -%}
-{% set _rgb2zy5_list = [_rgb2zy5[0]|float(0)|round(3),_rgb2zy5[1]|float(0)|round(3)] -%}
-{{ _rgb2zy5_list }}
-6 (using #5) macro xy to rgb list: {% set _xy2rgb6 = xy2rgb(_rgb2zy5_list).split(",") | list -%}
-{% set _xy2rgb6_list = [_xy2rgb6[0]|int(0),_xy2rgb6[1]|int(0),_xy2rgb6[2]|int(0)] -%}
-{{ _xy2rgb6_list }}
-8 (using #6) macro rgb to hs list: {% set _rgb2hs8 = rgb2hs(_xy2rgb6_list).split(",") | list -%}
-{% set _rgb2hs8_list = [_rgb2hs8[0]|float(0)|round(3),_rgb2hs8[1]|float(0)|round(3)] -%}
-{{ _rgb2hs8_list }}
-7 (using #8) macro hs to rgb list: {% set _hs2rgb7 = hs2rgb(_rgb2hs8_list).split(",") | list -%}
-{% set _hs2rgb7_list = [_hs2rgb7[0]|int(0),_hs2rgb7[1]|int(0),_hs2rgb7[2]|int(0)] -%}
-{{ _hs2rgb7_list }}
-A (using #8) macro hs to xy list: {% set _hs2xyA = hs2xy(_rgb2hs8_list).split(",") | list -%}
-{% set _hs2xyA_list = [_hs2xyA[0]|float(0)|round(3),_hs2xyA[1]|float(0)|round(3)] -%}
-{{ _hs2xyA_list }}
-9 (using #A) macro xy to hs list: {% set _xy2hs9 = xy2hs(_hs2xyA_list).split(",") | list -%}
-{% set _xy2hs9_list = [_xy2hs9[0]|float(0)|round(3),_xy2hs9[1]|float(0)|round(3)] -%}
-{{ _xy2hs9_list }}
--#}
+{%- set _nrgb4 = name2rgb(_nrgb4_name).split(",") | list %}
+{%- set _nrgb4_list = [_nrgb4[0]|int(0),_nrgb4[1]|int(0),_nrgb4[2]|int(0)] %}
+{{- _nrgb4_name }} -> {{ _nrgb4_list }}
+5 (using #4) macro rgb to xy list: {% set _rgb2zy5 = rgb2xy(_nrgb4_list).split(",") | list %}
+{%- set _rgb2zy5_list = [_rgb2zy5[0]|float(0)|round(3),_rgb2zy5[1]|float(0)|round(3)] %}
+{{- _nrgb4_list }} -> {{_rgb2zy5_list }}
+6 (using #5) macro xy to rgb list: {% set _xy2rgb6 = xy2rgb(_rgb2zy5_list).split(",") | list %}
+{%- set _xy2rgb6_list = [_xy2rgb6[0]|int(0),_xy2rgb6[1]|int(0),_xy2rgb6[2]|int(0)] %}
+{{- _rgb2zy5_list }} -> {{ _xy2rgb6_list }}
+8 (using #6) macro rgb to hs list: {% set _rgb2hs8 = rgb2hs(_xy2rgb6_list).split(",") | list %}
+{%- set _rgb2hs8_list = [_rgb2hs8[0]|float(0)|round(3),_rgb2hs8[1]|float(0)|round(3)] %}
+{{- _xy2rgb6_list }} -> {{ _rgb2hs8_list }}
+7 (using #8) macro hs to rgb list: {% set _hs2rgb7 = hs2rgb(_rgb2hs8_list).split(",") | list %}
+{%- set _hs2rgb7_list = [_hs2rgb7[0]|int(0),_hs2rgb7[1]|int(0),_hs2rgb7[2]|int(0)] %}
+{{- _rgb2hs8_list }} -> {{ _hs2rgb7_list }}
+A (using #8) macro hs to xy list: {% set _hs2xyA = hs2xy(_rgb2hs8_list).split(",") | list %}
+{%- set _hs2xyA_list = [_hs2xyA[0]|float(0)|round(3),_hs2xyA[1]|float(0)|round(3)] %}
+{{- _rgb2hs8_list }} -> {{ _hs2xyA_list }}
+9 (using #A) macro xy to hs list: {% set _xy2hs9 = xy2hs(_hs2xyA_list).split(",") | list %}
+{%- set _xy2hs9_list = [_xy2hs9[0]|float(0)|round(3),_xy2hs9[1]|float(0)|round(3)] %}
+{{- _hs2xyA_list }} -> {{ _xy2hs9_list }}
+
+{%- set _rgbl = [255,165,0] %}
+{{ chkRGB(_rgbl) | bool }}
+{%- set _xyl = [0.497,0.472] %}
+{{ chkXY(_xyl) | bool }}
+{%- set _hsl = [38.824,100.0] %}
+{{ chkHS(_hsl) | bool }}
+
+#}

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -1206,11 +1206,12 @@ A (using #8) macro hs to xy list: {% set _hs2xyA = hs2xy(_rgb2hs8_list).split(",
 {%- set _xy2hs9_list = [_xy2hs9[0]|float(0)|round(3),_xy2hs9[1]|float(0)|round(3)] %}
 {{- _hs2xyA_list }} -> {{ _xy2hs9_list }}
 
+Test the tests by changing the list values:
 {%- set _rgbl = [255,165,0] %}
-{{ chkRGB(_rgbl) | bool }}
+Check RGB: {{ chkRGB(_rgbl) | bool }}
 {%- set _xyl = [0.497,0.472] %}
-{{ chkXY(_xyl) | bool }}
+check XY : {{ chkXY(_xyl) | bool }}
 {%- set _hsl = [38.824,100.0] %}
-{{ chkHS(_hsl) | bool }}
+Check HS : {{ chkHS(_hsl) | bool }}
 
 #}

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -113,6 +113,53 @@
 {{- R -}},{{- G -}},{{- B -}}
 {% endmacro %}
 
+{% macro rgb2name(_range, rgbl) %}
+{#-
+  This template will accept a list representing an RGB value plus a range
+    value representing the window size of the 'close enough' color name.
+    It will return the Home Assistant Color name that matches it or is close
+    to it within a +/- range you specify.
+
+    > If you want only an exact match, then set the range to 0.
+    > If you think that +10/-10 is close enough, then set the range to 10.
+
+    For default the color is set to black [0,0,0] and the range is 0, so it will
+    by give you black for invalid input.
+
+  SAMPLE USAGE:
+    {% from 'color_multi_tool.jinja' import rgb2name %}
+    {{ name2rgb(color_name) }}
+
+  REMEMBER:
+    Everything returned from a macro template is a string.
+#}
+{%- if chkRGB(rgbl) | default(false) | bool %}
+{%- set out = ["black"] | list %}
+{%- set _rnge = _range | default(0) | round(0,0) %}
+{%- set iR = rgbl[0] | default(0) | int(0) %}
+{%- set iG = rgbl[1] | default(0) | int(0) %}
+{%- set iB = rgbl[2] | default(0) | int(0) %}
+{%- set _Rl = rgbl[0] + _rnge %}
+{%- set _Gl = rgbl[1] + _rnge %}
+{%- set _Bl = rgbl[2] + _rnge %}
+{%- set _Rg = rgbl[0] - _rnge %}
+{%- set _Gg = rgbl[1] - _rnge %}
+{%- set _Bg = rgbl[2] - _rnge %}
+{%- set out = _nameMap['_rgb'] |
+  selectattr('r', 'ge', _Rg) | 
+  selectattr('r', 'le', _Rl) | 
+  selectattr('g', 'ge', _Gg) |
+  selectattr('g', 'le', _Gl) |
+  selectattr('b', 'ge', _Bg) |
+  selectattr('b', 'le', _Bl) |
+  map(attribute='color') | list | default(['black']) %}
+{{- out -}}
+{%- else %}
+{#- Input was not valid #}
+{{-['black'] | list -}}
+{%- endif %}
+{% endmacro %}
+
 {% macro rgb2xy(rgbl) %}
 {#-
   This will return a CSV string that will convert to a list in the x,y format
@@ -173,7 +220,7 @@
     {%- set Y = 0.0 %}
   {%- endif %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set X = 0.0 %}
   {%- set Y = 0.0 %}
 {%- endif %}
@@ -243,7 +290,7 @@
   {%- set G = (g * 255) | int(0) %}
   {%- set B = (b * 255) | int(0) %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set R = 0 %}
   {%- set G = 0 %}
   {%- set B = 0 %}
@@ -319,7 +366,7 @@
     {%- set B = fV | int(0) %}
   {%- endif %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set R = 0 %}
   {%- set G = 0 %}
   {%- set B = 0 %}
@@ -385,7 +432,7 @@
     {%- set V = 0.0 %}
   {%- endif %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set H = 0.0 %}
   {%- set S = 0.0 %}
   {%- set V = 0.0 %}
@@ -420,7 +467,7 @@
   {%- set X = _rgb2xy_list[0] | float(0.0) | round(3) %}
   {%- set Y = _rgb2xy_list[1] | float(0.0) | round(3) %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set X = 0.0 %}
   {%- set Y = 0.0 %}
 {%- endif %}
@@ -454,7 +501,7 @@
   {%- set H = _rgb2hs_list[0] | float(0.0) | round(3) %}
   {%- set S = _rgb2hs_list[1] | float(0.0) | round(3) %}
 {%- else %}
-  {#- Input was not a list #}
+  {#- Input was not valid #}
   {%- set H = 0.0 %}
   {%- set S = 0.0 %}
 {%- endif %}
@@ -1197,7 +1244,7 @@ If any is not true, return false.
 {#-
 TESTING CODE FOR DEVELOPER TAB TO TEST THIS CUSTOM JINJA:
 {% from 'color_multi_tool.jinja' import random_name, random_xy, random_hs,
-random_rgb, name2rgb, rgb2xy, xy2rgb, hs2rgb, rgb2hs, xy2hs, hs2xy, chkRGB,
+random_rgb, name2rgb, rgb2name, rgb2xy, xy2rgb, hs2rgb, rgb2hs, xy2hs, hs2xy, chkRGB,
 chkXY, chkHS, chkNAME, color_list %}
 0 macro random name: {{ random_name() }}
 1 macro random xy list: {% set _rxy1 = random_xy().split(",") | list %}
@@ -1214,6 +1261,8 @@ chkXY, chkHS, chkNAME, color_list %}
 {%- set _nrgb4 = name2rgb(_nrgb4_name).split(",") | list %}
 {%- set _nrgb4_list = [_nrgb4[0]|int(0),_nrgb4[1]|int(0),_nrgb4[2]|int(0)] %}
 {{- _nrgb4_name }} -> {{ _nrgb4_list }}
+B (using #4) macro RGB to color name: {% set _rgb2name = rgb2name(20,_nrgb4_list) %}
+{{- _nrgb4_list }} -> {{ _rgb2name -}}
 5 (using #4) macro rgb to xy list: {% set _rgb2zy5 = rgb2xy(_nrgb4_list).split(",") | list %}
 {%- set _rgb2zy5_list = [_rgb2zy5[0]|float(0)|round(3),_rgb2zy5[1]|float(0)|round(3)] %}
 {{- _nrgb4_list }} -> {{_rgb2zy5_list }}

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -16,14 +16,15 @@
 #}
 {%- set _color_dict = _nameMap._rgb | random %}
 {{- _color_dict.color -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro random_xy() %}
 {#-
   This will return a CSV string that will convert to a list for a
     random color in the x,y format.
   Be sure to convert this to a list when you use it on the other end
-  because it arrives as a CSV string.
+    because it arrives as a CSV string.
+  Thanks to @123 for help cleaning up the random circuit [here](https://community.home-assistant.io/t/is-there-a-better-way-to-do-this-or-for-light-use-is-this-just-fine/667543/3).
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_xy %}
@@ -36,14 +37,15 @@
 
 {%- set (X,Y) = [range(1001),range(1001)] | map('random') | list %}
 {{- X/1000 -}},{{- Y/1000 -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro random_hs() %}
 {#-
   This will return a CSV string that will convert to a list for a
     random color in the h,s format.
   Be sure to convert this to a list when you use it on the other end
-  because it arrives as a CSV string.
+    because it arrives as a CSV string.
+  Thanks to @123 for help cleaning up the random circuit [here](https://community.home-assistant.io/t/is-there-a-better-way-to-do-this-or-for-light-use-is-this-just-fine/667543/3).
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_hs %}
@@ -55,14 +57,15 @@
 #}
 {%- set (H,S) = [range(36001),range(10001)] | map('random') | list %}
 {{- H/100 -}},{{- S/100 -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro random_rgb() %}
 {#-
   This will return a CSV string that will convert to a list for a
     random color in the rgb format.
   Be sure to convert this to a list when you use it on the other end
-  because it arrives as a CSV string.
+    because it arrives as a CSV string.
+  Thanks to @123 for help cleaning up the random circuit [here](https://community.home-assistant.io/t/is-there-a-better-way-to-do-this-or-for-light-use-is-this-just-fine/667543/3).
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import random_rgb %}
@@ -74,7 +77,7 @@
 #}
 {% set (R,G,B) = [range(256),range(256),range(256)] | map('random') | list %}
 {{- R -}},{{- G -}},{{- B -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro name2rgb(color_name) %}
 {#-
@@ -107,7 +110,7 @@
   {%- set B = 0 %}
 {%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro rgb2name(_range, rgbl) %}
 {#-
@@ -221,7 +224,7 @@
   {%- set Y = 0.0 %}
 {%- endif %}
 {{- X -}},{{- Y -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro xy2rgb(xyl) %}
 {#-
@@ -292,7 +295,7 @@
   {%- set B = 0 %}
 {%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro hs2rgb(hsl) %}
 {#-
@@ -368,7 +371,7 @@
   {%- set B = 0 %}
 {%- endif %}
 {{- R -}},{{- G -}},{{- B -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro rgb2hs(rgbl) %}
 {#-
@@ -434,7 +437,7 @@
   {%- set V = 0.0 %}
 {%- endif %}
 {{- H -}},{{- S -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro hs2xy(hsl) %}
 {#-
@@ -468,7 +471,7 @@
   {%- set Y = 0.0 %}
 {%- endif %}
 {{- X -}},{{- Y -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro xy2hs(xyl) %}
 {#-
@@ -502,7 +505,7 @@
   {%- set S = 0.0 %}
 {%- endif %}
 {{- H -}},{{- S -}}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro chkRGB(_rgbl) %}
 {#- Is the RGB list Valid? 
@@ -514,7 +517,7 @@ If all that is true return true.
 If any is not true, return false.
 Development credit to @Didgeridrew and @jeffcrum on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/3)
-for help sorting this out.
+  for help sorting this out.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import chkRGB %}
@@ -526,10 +529,12 @@ for help sorting this out.
 #}
 {%- if _rgbl is list and _rgbl | count == 3 %}
 {%- for clr in _rgbl if is_number(clr) and int(clr,0) == clr and 0 <= clr <= 255 %}
-{% if loop.last %}
-{{ loop.index == 3 }}
-{%- endif %}{% endfor%}{% else %}{{ false }}{%- endif %}
-{% endmacro %}
+{%- if loop.last %}
+{{- loop.index == 3 -}}
+{%- endif %}{%- endfor%}{%- else %}
+{{- false -}}
+{%- endif %}
+{%- endmacro %}
 
 {% macro chkXY(_xyl) %}
 {#- Is the XY list Valid? 
@@ -541,7 +546,7 @@ If all that is true return true.
 If any is not true, return false.
 Development credit to @123 on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
-for help sorting this out.
+  for help sorting this out.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import chkXY %}
@@ -554,8 +559,8 @@ for help sorting this out.
 {{- _xyl is list and
    _xyl | select('number') | list | count == 2 and
    _xyl | select('<', 0) | list | count == 0 and
-   _xyl | select('>', 1) | list | count == 0 }}
-{% endmacro %}
+   _xyl | select('>', 1) | list | count == 0 -}}
+{%- endmacro %}
 
 {% macro chkHS(_hsl) %}
 {#- Is the XY list Valid? 
@@ -568,7 +573,7 @@ If all that is true return true.
 If any is not true, return false.
 Development credit to @123 on the
 [Home Assistant Community Forums](https://community.home-assistant.io/t/help-with-test-of-a-list-of-numbers/664839/5)
-for help sorting this out.
+  for help sorting this out.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import chkHS %}
@@ -582,8 +587,8 @@ for help sorting this out.
    _hsl | select('number') | list | count == 2 and
    _hsl | select('<', 0) | list | count == 0 and
    _hsl[0] <= 100 and
-   _hsl[1] <= 360 }}
-{% endmacro %}
+   _hsl[1] <= 360 -}}
+{%- endmacro %}
 
 {% macro chkNAME(color_name) %}
 {#- Is this color name on the official list?
@@ -603,14 +608,18 @@ If any is not true, return false.
     This always returns text, so cast to bool on the other end to be
     certain of the result.
 #}
-{%- if color_name is string_like and 
+{%- if color_name is string_like and
   color_name == color_name | regex_replace('[^a-z]', '') %}
 {%- set ns = namespace(found = false) %}
 {%- for color_item in _nameMap._rgb %}
 {%- if color_item.color == color_name %}
 {%- set ns.found = true %}
-{%- break %}{% endif %}{% endfor %}{{ ns.found }}{% else %}{{ false }}{% endif %}
-{% endmacro %}
+{%- break %}{%- endif %}{%- endfor %}
+{{- ns.found -}}
+{%- else %}
+{{- false -}}
+{%- endif %}
+{%- endmacro %}
 
 {% macro color_list() %}
 {#-
@@ -627,12 +636,13 @@ If any is not true, return false.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import color_list %}
-    {{- color_list() -}}
+    {{- color_list().split('\n') | list -}}
 #}
-{%- for dict_item in _nameMap._rgb %}
-{{ dict_item.color -}},{{- dict_item.r -}},{{- dict_item.g -}},{{- dict_item.b -}}
+{%- for colors in _nameMap._rgb -%}
+{%- set c_list = {colors.color:[colors.r,colors.g,colors.b]} %}
+{{ c_list }}
 {%- endfor %}
-{% endmacro %}
+{%- endmacro %}
 
 {#- COLOR NAME TO RGB MAP DATA. DO NOT CHANGE BELOW THIS LINE
     (unless you want to add your own custom color that is...): #}
@@ -1255,7 +1265,7 @@ chkXY, chkHS, chkNAME, color_list %}
 
 4 macro name to rgb list: {% set _nrgb4_name = random_name() %}
 {%- set _nrgb4 = name2rgb(_nrgb4_name).split(",") | list %}
-{%- set _nrgb4_list = [_nrgb4[0]|int(0),_nrgb4[1]|int(0),_nrgb4[2]|int(0)] %}
+{%- set _nrgb4_list = [_nrgb4[0]|int(0),_nrgb4[1]|int(0),_nrgb4[2]|int(0)] | list %}
 {{- _nrgb4_name }} -> {{ _nrgb4_list }}
 B (using #4) macro RGB to color name: {% set _rgb2name = rgb2name(20,_nrgb4_list) %}
 {{- _nrgb4_list }} -> {{ _rgb2name -}}
@@ -1289,6 +1299,6 @@ Check HS :   {{ chkHS(_hsl) | bool }}
 Check NAME : {{ chkNAME(_name) | bool }}
 
 Test color_list:
-{{- color_list() }}
+{{ color_list().split('\n') | list }}
 
 #}

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -639,9 +639,9 @@ If any is not true, return false.
     {{- color_list().split('\n') | list -}}
 #}
 {%- for colors in _nameMap._rgb -%}
-{%- set c_list = {colors.color:[colors.r,colors.g,colors.b]} %}
-{{ c_list }}
-{%- endfor %}
+{%- set c_list = {colors.color:[colors.r,colors.g,colors.b]} -%}
+{{- c_list ~ '\n'-}}
+{%- endfor -%}
 {%- endmacro %}
 
 {#- COLOR NAME TO RGB MAP DATA. DO NOT CHANGE BELOW THIS LINE

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -581,9 +581,9 @@ If any is not true, return false.
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen". 
     You also get the RGB color code for each of the color names.
-  
+
   SAMPLE USAGE:
-    {% from 'color_multi_tool.jinja' import randomcolor_list_name %}
+    {% from 'color_multi_tool.jinja' import color_list %}
     {{- color_list() -}}
 #}
 {%- for dict_item in _nameMap._rgb %}
@@ -1246,3 +1246,4 @@ Check NAME : {{ chkNAME(_name) | bool }}
 Test color_list:
 {{- color_list() }}
 
+#}


### PR DESCRIPTION
Did some work to complete the rest of the To Do list documented in the first releases.
All these items have now been completed:
      # 🦠 TO-DO List
      
      - Push to HACS Custom.
      - Error checking inputs for range.
      - Return a list of all the official color names.
      - Clean-up code, add shortcuts on redundancies.
      - Add ```Display closest color name to a given RGB```
      - Push to HACS released.

