### PR TITLE
change output of rgb2name to csv string

### DIFF
--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -122,7 +122,7 @@
     compare against requests more easily .
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen".
-  If the exact name is not found, it will return "0.0.0", IE black,
+  If the exact name is not found, it will return "0.0.0", IE ,
     because then name you provided is not a color on the official list.
 
   SAMPLE USAGE:
@@ -164,8 +164,8 @@
     > If you want only an exact match, then set the range to 0.
     > If you think that +10/-10 is close enough, then set the range to 10.
 
-    For default the color is set to black [0,0,0] and the range is 0, so it will
-    give you black for invalid input.
+    For default the color is set to  [0,0,0] and the range is 0, so it will
+    give you  for invalid input.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2name %}
@@ -210,7 +210,7 @@
 {{- out -}}
 {%- else %}
   {#- Input was not valid #}
-{{-['black'] | list | join(',') -}}
+{{- 'black' -}}
 {%- endif -%}
 {% endmacro -%}
 

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -122,7 +122,7 @@
     compare against requests more easily .
     This lets "dark seagreen" and "dark sea green" both match the same
     color "darkseagreen".
-  If the exact name is not found, it will return "0.0.0", IE ,
+  If the exact name is not found, it will return "0.0.0", IE black,
     because then name you provided is not a color on the official list.
 
   SAMPLE USAGE:
@@ -164,8 +164,8 @@
     > If you want only an exact match, then set the range to 0.
     > If you think that +10/-10 is close enough, then set the range to 10.
 
-    For default the color is set to  [0,0,0] and the range is 0, so it will
-    give you  for invalid input.
+    For default the color is set to black [0,0,0] and the range is 0, so it will
+    give you black for invalid input.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2name %}
@@ -210,7 +210,7 @@
 {{- out -}}
 {%- else %}
   {#- Input was not valid #}
-{{- 'black' -}}
+{{-['black'] | list | join(',') -}}
 {%- endif -%}
 {% endmacro -%}
 

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -210,7 +210,7 @@
 {{- out -}}
 {%- else %}
   {#- Input was not valid #}
-{{-['black'] | list | join(',') -}}
+{{- 'black' -}}
 {%- endif -%}
 {% endmacro -%}
 

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -165,11 +165,11 @@
     > If you think that +10/-10 is close enough, then set the range to 10.
 
     For default the color is set to black [0,0,0] and the range is 0, so it will
-    by give you black for invalid input.
+    give you black for invalid input.
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2name %}
-    {{ name2rgb(color_name) }}
+    {{ rgb2name(color_name) }}
 
   REMEMBER:
     Everything returned from a macro template is a string.

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -206,13 +206,13 @@
   selectattr('g', 'le', _Gl) |
   selectattr('b', 'ge', _Bg) |
   selectattr('b', 'le', _Bl) |
-  map(attribute='color') | list | default(['black']) %}
+  map(attribute='color') | list | default(['black']) | join(',') %}
 {{- out -}}
 {%- else %}
   {#- Input was not valid #}
-{{-['black'] | list -}}
-{%- endif %}
-{% endmacro %}
+{{-['black'] | list | join(',') -}}
+{%- endif -%}
+{% endmacro -%}
 
 {% macro rgb2xy(rgbl) %}
 {#-

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -211,8 +211,8 @@
 {%- else %}
   {#- Input was not valid #}
 {{- 'black' -}}
-{%- endif -%}
-{% endmacro -%}
+{%- endif %}
+{%- endmacro %}
 
 {% macro rgb2xy(rgbl) %}
 {#-


### PR DESCRIPTION
Change the output of rgb2name to CSV string. So it's possible to convert the output to a list again after calling the function.
Also remove a linebreak from the output.

#### To test:
```
{% from 'color_multi_tool.jinja' import rgb2name %}
{%- set rgbl = (254,159,70) | list %}
{{ rgb2name(40, rgbl) }}
{{ rgb2name(40, rgbl).split(',') }}
{{ rgb2name(40, rgbl).split(',')[0] }}
```
output:
```
coral,goldenrod,sandybrown
['coral', 'goldenrod', 'sandybrown']
coral
```