### PR TITLE
rgb2name typo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ Another good thing to do before you ask for help is try testing what you have in
   SAMPLE USAGE:
 
   ```jinja
-    {% from 'color_multi_tool.jinja' import name2rgb %}
-    {{ rgb2name(10, rgbl) }}
+    {% from 'color_multi_tool.jinja' import rgb2name %}
+    {{ rgb2name(rgbl,10) }}
   ```
 
   REMEMBER:

--- a/color_multi_tool.jinja
+++ b/color_multi_tool.jinja
@@ -169,7 +169,7 @@
 
   SAMPLE USAGE:
     {% from 'color_multi_tool.jinja' import rgb2name %}
-    {{ name2rgb(color_name) }}
+    {{ rgb2name(10,rgbl) }}
 
   REMEMBER:
     Everything returned from a macro template is a string.


### PR DESCRIPTION
Fixed this:

[Didgeridrew](https://community.home-assistant.io/u/Didgeridrew)
Regular
[2h](https://community.home-assistant.io/t/re-color-multi-tool/863257?u=sir_goodenough)

There’s a typo in the rgb2name() example on the project page https://community.home-assistant.io/t/color-multi-tool/659958.

image
[image681×117 4.33 KB](https://community-assets.home-assistant.io/original/4X/0/9/9/099f07fbdf56ae328927be5b9808d9304ef10442.png)

And a similar typo in the jinja file’s example, but in the expression:

image
[image681×117 4.42 KB](https://community-assets.home-assistant.io/original/4X/d/f/1/df1fa4bb1839a12650c94dcda40dd8e8e4a7a993.png)